### PR TITLE
feat: cpu parallel fasta and line matchers

### DIFF
--- a/ish_bench_aligner_gpu.mojo
+++ b/ish_bench_aligner_gpu.mojo
@@ -956,8 +956,8 @@ fn bench_basic_semi_global(
                 var result = semi_global_parasail[DType.int16](
                     query[].seq,
                     target[].seq,
-                    # matrix,
-                    basic_matrix,
+                    matrix,
+                    # basic_matrix,
                     gap_open_penalty=-gap_open_score,
                     gap_extension_penalty=-gap_extension_score,
                     free_query_start_gaps=True,
@@ -1101,8 +1101,6 @@ fn bench_striped_semi_global_parallel(
 
             fn do_alignment(index: Int) capturing:
                 var target = Pointer.address_of(targets[index])
-                if index == 532959:
-                    print("532959 is:", targets[index].name)
                 var result = semi_global_aln_with_saturation_check[
                     SIMD_U8_WIDTH,
                     SIMD_U16_WIDTH,

--- a/ishlib/matcher/__init__.mojo
+++ b/ishlib/matcher/__init__.mojo
@@ -17,7 +17,17 @@ trait Matcher(Copyable, Movable):
     """Trait for how matchers must work."""
 
     fn first_match(
-        mut self, haystack: Span[UInt8], pattern: Span[UInt8]
+        read self, haystack: Span[UInt8], pattern: Span[UInt8]
     ) -> Optional[MatchResult]:
         """Find the first match in the haystack."""
+        ...
+
+    @always_inline
+    fn convert_ascii_to_encoding(read self, value: UInt8) -> UInt8:
+        """Convert an ascii byte to an encoded byte."""
+        ...
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, value: UInt8) -> UInt8:
+        """Convert an encoded byte to an ascii byte."""
         ...

--- a/ishlib/matcher/alignment/local_aln/striped.mojo
+++ b/ishlib/matcher/alignment/local_aln/striped.mojo
@@ -51,8 +51,8 @@ struct Profile[SIMD_U8_WIDTH: Int, SIMD_U16_WIDTH: Int]:
 
     var profile_byte: Optional[Self.ByteVProfile]
     var profile_word: Optional[Self.WordVProfile]
-    var byte_vectors: ProfileVectors[DType.uint8, SIMD_U8_WIDTH]
-    var word_vectors: ProfileVectors[DType.uint16, SIMD_U16_WIDTH]
+    # var byte_vectors: ProfileVectors[DType.uint8, SIMD_U8_WIDTH]
+    # var word_vectors: ProfileVectors[DType.uint16, SIMD_U16_WIDTH]
     var query_len: Int32
     var alphabet_size: UInt32
     var bias: UInt8
@@ -104,8 +104,8 @@ struct Profile[SIMD_U8_WIDTH: Int, SIMD_U16_WIDTH: Int]:
         return Self(
             profile_byte,
             profile_word,
-            ProfileVectors[DType.uint8, SIMD_U8_WIDTH](len(query)),
-            ProfileVectors[DType.uint16, SIMD_U16_WIDTH](len(query)),
+            # ProfileVectors[DType.uint8, SIMD_U8_WIDTH](len(query)),
+            # ProfileVectors[DType.uint16, SIMD_U16_WIDTH](len(query)),
             len(query),
             score_matrix.size,
             bias,
@@ -158,11 +158,11 @@ struct Profile[SIMD_U8_WIDTH: Int, SIMD_U16_WIDTH: Int]:
 fn ssw_align[
     SIMD_U8_WIDTH: Int, SIMD_U16_WIDTH: Int
 ](
-    mut profile: Profile[SIMD_U8_WIDTH, SIMD_U16_WIDTH],
+    read profile: Profile[SIMD_U8_WIDTH, SIMD_U16_WIDTH],
     read matrix: ScoringMatrix,
     reference: Span[UInt8],
     query: Span[UInt8],
-    mut reverse_profile: Profile[SIMD_U8_WIDTH, SIMD_U16_WIDTH],
+    read reverse_profile: Profile[SIMD_U8_WIDTH, SIMD_U16_WIDTH],
     *,
     gap_open_penalty: UInt8 = 3,
     gap_extension_penalty: UInt8 = 1,
@@ -184,7 +184,7 @@ fn ssw_align[
             gap_open_penalty,
             gap_extension_penalty,
             profile.profile_byte.value(),
-            profile.byte_vectors,
+            # profile.byte_vectors,
             -1,
             profile.bias,
             mask_length,
@@ -197,7 +197,7 @@ fn ssw_align[
                 gap_open_penalty.cast[DType.uint16](),
                 gap_extension_penalty.cast[DType.uint16](),
                 profile.profile_word.value(),
-                profile.word_vectors,
+                # profile.word_vectors,
                 -1,
                 profile.bias.cast[DType.uint16](),
                 mask_length,
@@ -218,7 +218,7 @@ fn ssw_align[
             gap_open_penalty.cast[DType.uint16](),
             gap_extension_penalty.cast[DType.uint16](),
             profile.profile_word.value(),
-            profile.word_vectors,
+            # profile.word_vectors,
             -1,
             profile.bias.cast[DType.uint16](),
             mask_length,
@@ -259,7 +259,7 @@ fn ssw_align[
             gap_open_penalty,
             gap_extension_penalty,
             reverse_profile.profile_byte.value(),
-            reverse_profile.byte_vectors,
+            # reverse_profile.byte_vectors,
             -1,
             reverse_profile.bias,
             mask_length,
@@ -272,7 +272,7 @@ fn ssw_align[
             gap_open_penalty.cast[DType.uint16](),
             gap_extension_penalty.cast[DType.uint16](),
             reverse_profile.profile_word.value(),
-            reverse_profile.word_vectors,
+            # reverse_profile.word_vectors,
             -1,
             reverse_profile.bias.cast[DType.uint16](),
             mask_length,
@@ -301,7 +301,7 @@ fn sw[
     gap_open_penalty: SIMD[dt, 1],
     gap_extension_penalty: SIMD[dt, 1],
     profile: Span[SIMD[dt, width]],
-    mut p_vecs: ProfileVectors[dt, width],
+    # mut p_vecs: ProfileVectors[dt, width],
     terminate: SIMD[dt, 1],
     bias: SIMD[dt, 1],
     mask_length: Int32,
@@ -312,7 +312,8 @@ fn sw[
         terminate: The best alignment score, used to terminate the matrix calc when locating the alignment beginning point. If this score is set to 0, it will not be used.
 
     """
-    p_vecs.zero_out()
+    var p_vecs = ProfileVectors[dt, width](query_len)
+    # p_vecs.zero_out()
     p_vecs.init_columns(len(reference))
     var max_score = UInt8(0).cast[dt]()
     var end_query: Int32 = query_len - 1

--- a/ishlib/matcher/alignment/scoring_matrix.mojo
+++ b/ishlib/matcher/alignment/scoring_matrix.mojo
@@ -304,6 +304,10 @@ struct ScoringMatrix:
         return out
 
     @always_inline
+    fn convert_ascii_to_encoding(read self, seq: UInt8) -> UInt8:
+        return self.ascii_to_encoding[Int(seq)]
+
+    @always_inline
     fn convert_ascii_to_encoding(
         read self, owned seq: List[UInt8]
     ) -> List[UInt8]:
@@ -324,3 +328,7 @@ struct ScoringMatrix:
         for value in seq:
             out.append(self.encoding_to_ascii[Int(value[])])
         return out
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, seq: UInt8) -> UInt8:
+        return self.encoding_to_ascii[Int(seq)]

--- a/ishlib/matcher/alignment/semi_global_aln/basic.mojo
+++ b/ishlib/matcher/alignment/semi_global_aln/basic.mojo
@@ -28,7 +28,7 @@ struct SGResult(StringableRaising):
         )
 
 
-fn semi_global_parasail_start_end_end[
+fn semi_global_parasail_start_end[
     DT: DType = DType.int32
 ](
     query: Span[UInt8],
@@ -98,8 +98,7 @@ fn semi_global_parasail[
 ](
     query: Span[UInt8],
     target: Span[UInt8],
-    # read scoring_matrix: ScoringMatrix,
-    read scoring_matrix: BasicScoringMatrix,
+    read scoring_matrix: ScoringMatrix,
     *,
     gap_open_penalty: Scalar[DT] = -3,
     gap_extension_penalty: Scalar[DT] = -1,
@@ -322,7 +321,6 @@ fn semi_global_parasail_gpu[
         if not free_target_start_gaps:
             WH = gap_open_penalty + ((i - 1) * gap_extension_penalty)
 
-        # var WH = 0 if free_target_start_gaps else
         var E = HALF_MIN
         H[0] = WH
 

--- a/ishlib/matcher/alignment/semi_global_aln/striped.mojo
+++ b/ishlib/matcher/alignment/semi_global_aln/striped.mojo
@@ -5,6 +5,7 @@ from collections import InlineArray
 from math import sqrt, iota
 from memory import pack_bits, memset_zero
 
+from ishlib.matcher.alignment import create_reversed
 from ishlib.matcher.alignment.scoring_matrix import ScoringMatrix
 from ishlib.matcher.alignment.striped_utils import (
     saturating_sub,
@@ -126,7 +127,6 @@ fn semi_global_aln_start_end[
     dt: DType, width: Int, *, do_saturation_check: Bool = True
 ](
     reference: Span[UInt8],
-    rev_reference: Span[UInt8],
     query_len: Int32,
     gap_open_penalty: SIMD[dt, 1],
     gap_extension_penalty: SIMD[dt, 1],
@@ -164,6 +164,7 @@ fn semi_global_aln_start_end[
     if forward.best.score < score_cutoff:
         return None
 
+    var rev_reference = create_reversed(reference)
     var reverse = semi_global_aln[
         dt, width, do_saturation_check=do_saturation_check
     ](

--- a/ishlib/matcher/basic_global_matcher.mojo
+++ b/ishlib/matcher/basic_global_matcher.mojo
@@ -17,7 +17,7 @@ struct BasicGlobalMatcher(Matcher):
         self.scoring_matrix = ScoringMatrix.all_ascii_default_matrix()
 
     fn first_match(
-        mut self, haystack: Span[UInt8], pattern: Span[UInt8]
+        read self, haystack: Span[UInt8], pattern: Span[UInt8]
     ) -> Optional[MatchResult]:
         """Find the first match in the haystack."""
         var result = needleman_wunsch_parasail[DType.int16](
@@ -33,3 +33,14 @@ struct BasicGlobalMatcher(Matcher):
             )
 
         return None
+
+    @always_inline
+    fn convert_ascii_to_encoding(read self, value: UInt8) -> UInt8:
+        """Convert an ascii byte to an encoded byte."""
+        return self.scoring_matrix.convert_ascii_to_encoding(value)
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, value: UInt8) -> UInt8:
+        """Convert an encoded byte to an ascii byte."""
+
+        return self.scoring_matrix.convert_encoding_to_ascii(value)

--- a/ishlib/matcher/basic_local_matcher.mojo
+++ b/ishlib/matcher/basic_local_matcher.mojo
@@ -1,12 +1,20 @@
 """Smith-Waterman local alignment."""
 from ishlib.matcher import Matcher, MatchResult
+from ishlib.matcher.alignment.scoring_matrix import ScoringMatrix
 from ishlib.matcher.alignment.local_aln.basic import smith_waterman
 
 
 @value
 struct BasicLocalMatcher(Matcher):
+    var pattern: List[UInt8]
+    var scoring_matrix: ScoringMatrix
+
+    fn __init__(out self, pattern: Span[UInt8]):
+        self.pattern = List(pattern)  # assuming ascii matrix
+        self.scoring_matrix = ScoringMatrix.all_ascii_default_matrix()
+
     fn first_match(
-        mut self, haystack: Span[UInt8], pattern: Span[UInt8]
+        read self, haystack: Span[UInt8], pattern: Span[UInt8]
     ) -> Optional[MatchResult]:
         """Find the first match in the haystack."""
         var result = smith_waterman(
@@ -18,3 +26,13 @@ struct BasicLocalMatcher(Matcher):
             )
 
         return None
+
+    @always_inline
+    fn convert_ascii_to_encoding(read self, value: UInt8) -> UInt8:
+        """Convert an ascii byte to an encoded byte."""
+        return self.scoring_matrix.convert_ascii_to_encoding(value)
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, value: UInt8) -> UInt8:
+        """Convert an encoded byte to an ascii byte."""
+        return self.scoring_matrix.convert_encoding_to_ascii(value)

--- a/ishlib/matcher/basic_semi_global_matcher.mojo
+++ b/ishlib/matcher/basic_semi_global_matcher.mojo
@@ -3,7 +3,7 @@ from ishlib.matcher import Matcher, MatchResult
 from ishlib.matcher.alignment import create_reversed
 from ishlib.matcher.alignment.scoring_matrix import ScoringMatrix
 from ishlib.matcher.alignment.semi_global_aln.basic import (
-    semi_global_parasail_start_end_end,
+    semi_global_parasail_start_end,
 )
 
 
@@ -19,13 +19,13 @@ struct BasicSemiGlobalMatcher(Matcher):
         self.scoring_matrix = ScoringMatrix.all_ascii_default_matrix()
 
     fn first_match(
-        mut self, haystack: Span[UInt8], pattern: Span[UInt8]
+        read self, haystack: Span[UInt8], pattern: Span[UInt8]
     ) -> Optional[MatchResult]:
         """Find the first match in the haystack."""
 
         var rev_haystack = create_reversed(haystack)
 
-        var result = semi_global_parasail_start_end_end[DType.int16](
+        var result = semi_global_parasail_start_end[DType.int16](
             self.pattern,
             haystack,  # assuming ascii matrix so we can skip encoding
             self.rev_pattern,
@@ -48,3 +48,13 @@ struct BasicSemiGlobalMatcher(Matcher):
             )
 
         return None
+
+    @always_inline
+    fn convert_ascii_to_encoding(read self, value: UInt8) -> UInt8:
+        """Convert an ascii byte to an encoded byte."""
+        return self.scoring_matrix.convert_ascii_to_encoding(value)
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, value: UInt8) -> UInt8:
+        """Convert an encoded byte to an ascii byte."""
+        return self.scoring_matrix.convert_encoding_to_ascii(value)

--- a/ishlib/matcher/naive_exact_matcher.mojo
+++ b/ishlib/matcher/naive_exact_matcher.mojo
@@ -1,11 +1,19 @@
 """Naive linear exact match search."""
 from ishlib.matcher import Matcher, MatchResult
+from ishlib.matcher.alignment.scoring_matrix import ScoringMatrix
 
 
 @value
 struct NaiveExactMatcher(Matcher):
+    var pattern: List[UInt8]
+    var scoring_matrix: ScoringMatrix
+
+    fn __init__(out self, pattern: Span[UInt8]):
+        self.pattern = List(pattern)  # assuming ascii matrix
+        self.scoring_matrix = ScoringMatrix.all_ascii_default_matrix()
+
     fn first_match(
-        mut self, haystack: Span[UInt8], pattern: Span[UInt8]
+        read self, haystack: Span[UInt8], pattern: Span[UInt8]
     ) -> Optional[MatchResult]:
         """Find the first match in the haystack."""
 
@@ -19,3 +27,13 @@ struct NaiveExactMatcher(Matcher):
                 return MatchResult(h, h + len(pattern))
 
         return None
+
+    @always_inline
+    fn convert_ascii_to_encoding(read self, value: UInt8) -> UInt8:
+        """Convert an ascii byte to an encoded byte."""
+        return self.scoring_matrix.convert_ascii_to_encoding(value)
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, value: UInt8) -> UInt8:
+        """Convert an encoded byte to an ascii byte."""
+        return self.scoring_matrix.convert_encoding_to_ascii(value)

--- a/ishlib/matcher/striped_local_matcher.mojo
+++ b/ishlib/matcher/striped_local_matcher.mojo
@@ -39,7 +39,7 @@ struct StripedLocalMatcher[mut: Bool, //, origin: Origin[mut]](Matcher):
         self.reverse_profile = reverse_profile
 
     fn first_match(
-        mut self, haystack: Span[UInt8], pattern: Span[UInt8]
+        read self, haystack: Span[UInt8], pattern: Span[UInt8]
     ) -> Optional[MatchResult]:
         """Find the first match in the haystack."""
         var result = ssw_align(
@@ -63,3 +63,13 @@ struct StripedLocalMatcher[mut: Bool, //, origin: Origin[mut]](Matcher):
             )
 
         return None
+
+    @always_inline
+    fn convert_ascii_to_encoding(read self, value: UInt8) -> UInt8:
+        """Convert an ascii byte to an encoded byte."""
+        return self.matrix.convert_ascii_to_encoding(value)
+
+    @always_inline
+    fn convert_encoding_to_ascii(read self, value: UInt8) -> UInt8:
+        """Convert an encoded byte to an ascii byte."""
+        return self.matrix.convert_encoding_to_ascii(value)

--- a/ishlib/parallel_fasta_search_runner.mojo
+++ b/ishlib/parallel_fasta_search_runner.mojo
@@ -1,0 +1,85 @@
+from ExtraMojo.io.buffered import BufferedReader, BufferedWriter
+
+from ishlib.formats.fasta import (
+    FastaReader,
+    BorrowedFastaRecord,
+    ByteFastaRecord,
+)
+from ishlib.searcher_settings import SearcherSettings
+from ishlib.matcher import Matcher, MatchResult
+from ishlib import ByteSpanWriter
+
+from algorithm.functional import parallelize
+from utils import StringSlice
+from sys import stdout, info
+
+
+@value
+struct ParallelFastaSearchRunner[M: Matcher]:
+    var settings: SearcherSettings
+    var matcher: M
+
+    fn run_search(mut self) raises:
+        # Simple thing first?
+        for file in self.settings.files:
+            var f = file[]  # force copy
+            self.run_search_on_file(f)
+
+    fn run_search_on_file(mut self, file: String) raises:
+        # TODO: pass an enocoder to the FastaReader
+        var reader = FastaReader(BufferedReader(open(file, "r")))
+        var writer = BufferedWriter(stdout)
+
+        var sequences = List[ByteFastaRecord]()
+        var bytes_saved = 0
+
+        # TODO: hold onto the non-newline stripped sequence as well for outputting the match color
+
+        var do_work = True
+        while do_work:
+            var record = reader.read_owned(self.matcher)
+
+            if not record:
+                do_work = False
+            else:
+                bytes_saved += record.value().size_in_bytes()
+                sequences.append(record.value())
+
+            if bytes_saved >= self.settings.batch_size or not do_work:
+                var outputs = self.par(sequences)
+                for i in range(0, len(outputs)):
+                    var m = outputs[i]
+                    if not m:
+                        continue
+                    var r = Pointer.address_of(sequences[i])
+                    writer.write(">")
+                    writer.write_bytes(r[].name)
+                    writer.write("\n")
+                    writer.write_bytes(r[].seq[0 : m.value().start])
+                    writer.write("\033[1;31m")
+                    writer.write_bytes(r[].seq[m.value().start : m.value().end])
+                    writer.write()
+                    writer.write("\033[0m")
+                    writer.write_bytes(r[].seq[m.value().end :])
+                    writer.write("\n")
+                sequences.clear()
+                bytes_saved = 0
+        writer.flush()
+        writer.close()
+
+    fn par(
+        read self, read seqs: Span[ByteFastaRecord]
+    ) -> List[Optional[MatchResult]]:
+        # TODO: reusable output buffer
+        var output = List[Optional[MatchResult]](capacity=len(seqs))
+        for _ in range(0, len(seqs)):
+            output.append(None)
+
+        fn do_matching(index: Int) capturing:
+            var target = Pointer.address_of(seqs[index])
+            output[index] = self.matcher.first_match(
+                target[].seq, self.settings.pattern
+            )
+
+        parallelize[do_matching](len(seqs), self.settings.threads)
+        return output

--- a/ishlib/parallel_line_search_runner.mojo
+++ b/ishlib/parallel_line_search_runner.mojo
@@ -1,0 +1,95 @@
+from ExtraMojo.io.buffered import BufferedReader, BufferedWriter
+
+from ishlib.formats.fasta import (
+    FastaReader,
+    BorrowedFastaRecord,
+    ByteFastaRecord,
+)
+from ishlib.searcher_settings import SearcherSettings
+from ishlib.matcher import Matcher, MatchResult
+from ishlib import ByteSpanWriter
+
+from algorithm.functional import parallelize
+from utils import StringSlice
+from sys import stdout, info
+
+
+@value
+struct ParallelLineSearchRunner[M: Matcher]:
+    var settings: SearcherSettings
+    var matcher: M
+
+    fn run_search(mut self) raises:
+        # Simple thing first?
+        for file in self.settings.files:
+            var f = file[]  # force copy
+            self.run_search_on_file(f)
+
+    fn run_search_on_file(mut self, file: String) raises:
+        # TODO: pass an enocoder to the FastaReader
+        var reader = BufferedReader(open(file, "r"))
+        var writer = BufferedWriter(stdout)
+
+        var lines = List[List[UInt8]]()
+        var bytes_saved = 0
+        var buffer = List[UInt8]()
+        var line_number = 0
+
+        # TODO: hold onto the non-newline stripped sequence as well for outputting the match color
+
+        var do_work = True
+        while do_work:
+            buffer.clear()
+            if reader.read_until(buffer) == 0:
+                do_work = False
+            else:
+                var line = List[UInt8](capacity=len(buffer))
+                for i in range(0, len(buffer)):
+                    line.append(
+                        self.matcher.convert_ascii_to_encoding(buffer[i])
+                    )
+                bytes_saved += len(line)
+                lines.append(line)
+
+            if bytes_saved >= self.settings.batch_size or not do_work:
+                var outputs = self.par(lines)
+                for i in range(0, len(outputs)):
+                    var m = outputs[i]
+                    if not m:
+                        continue
+                    var r = Pointer.address_of(lines[i])
+                    writer.write(
+                        file,
+                        ":",
+                        line_number,
+                        " ",
+                        # ByteSpanWriter(buffer[:]),
+                        ByteSpanWriter(r[][0 : m.value().start]),
+                        "\033[1;31m",
+                        ByteSpanWriter(r[][m.value().start : m.value().end]),
+                        "\033[0m",
+                        ByteSpanWriter(r[][m.value().end :]),
+                        "\n",
+                    )
+                    line_number += 1
+                lines.clear()
+                bytes_saved = 0
+        writer.flush()
+        writer.close()
+
+    fn par(
+        read self, read seqs: Span[List[UInt8]]
+    ) -> List[Optional[MatchResult]]:
+        # TODO: reusable output buffer
+        var output = List[Optional[MatchResult]](capacity=len(seqs))
+        for _ in range(0, len(seqs)):
+            output.append(None)
+
+        fn do_matching(index: Int) capturing:
+            var target = Pointer.address_of(seqs[index])
+            output[index] = self.matcher.first_match(
+                target[], self.settings.pattern
+            )
+
+        parallelize[do_matching](len(seqs), self.settings.threads)
+        return output

--- a/main.mojo
+++ b/main.mojo
@@ -1,6 +1,8 @@
 from ishlib.searcher_settings import SearcherSettings
 from ishlib.line_search_runner import LineSearchRunner
+from ishlib.parallel_line_search_runner import ParallelLineSearchRunner
 from ishlib.fasta_search_runner import FastaSearchRunner
+from ishlib.parallel_fasta_search_runner import ParallelFastaSearchRunner
 from ishlib.matcher.basic_global_matcher import BasicGlobalMatcher
 from ishlib.matcher.basic_semi_global_matcher import BasicSemiGlobalMatcher
 from ishlib.matcher.naive_exact_matcher import NaiveExactMatcher
@@ -19,80 +21,152 @@ fn main() raises:
 
     if settings.match_algo == "naive_exact":
         if settings.record_type == "line":
-            var runner = LineSearchRunner[NaiveExactMatcher](
-                settings, NaiveExactMatcher()
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = LineSearchRunner[NaiveExactMatcher](
+                    settings, NaiveExactMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelLineSearchRunner[NaiveExactMatcher](
+                    settings, NaiveExactMatcher(settings.pattern)
+                )
+                runner.run_search()
         elif settings.record_type == "fasta":
-            var runner = FastaSearchRunner[NaiveExactMatcher](
-                settings, NaiveExactMatcher()
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = FastaSearchRunner[NaiveExactMatcher](
+                    settings, NaiveExactMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelFastaSearchRunner[NaiveExactMatcher](
+                    settings, NaiveExactMatcher(settings.pattern)
+                )
+                runner.run_search()
         else:
             raise "Invalid record type: {}".format(settings.record_type)
     elif settings.match_algo == "basic-local":
         if settings.record_type == "line":
-            var runner = LineSearchRunner[BasicLocalMatcher](
-                settings, BasicLocalMatcher()
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = LineSearchRunner[BasicLocalMatcher](
+                    settings, BasicLocalMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelLineSearchRunner[BasicLocalMatcher](
+                    settings, BasicLocalMatcher(settings.pattern)
+                )
+                runner.run_search()
         elif settings.record_type == "fasta":
-            var runner = FastaSearchRunner[BasicLocalMatcher](
-                settings, BasicLocalMatcher()
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = FastaSearchRunner[BasicLocalMatcher](
+                    settings, BasicLocalMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelFastaSearchRunner[BasicLocalMatcher](
+                    settings, BasicLocalMatcher(settings.pattern)
+                )
+                runner.run_search()
         else:
             raise "Invalid record type: {}".format(settings.record_type)
     elif settings.match_algo == "striped-local":
         if settings.record_type == "line":
-            var runner = LineSearchRunner[
-                StripedLocalMatcher[__origin_of(settings.pattern)]
-            ](settings, StripedLocalMatcher(settings.pattern))
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = LineSearchRunner[
+                    StripedLocalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedLocalMatcher(settings.pattern))
+                runner.run_search()
+            else:
+                var runner = ParallelLineSearchRunner[
+                    StripedLocalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedLocalMatcher(settings.pattern))
+                runner.run_search()
         elif settings.record_type == "fasta":
-            var runner = FastaSearchRunner[
-                StripedLocalMatcher[__origin_of(settings.pattern)]
-            ](settings, StripedLocalMatcher(settings.pattern))
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = FastaSearchRunner[
+                    StripedLocalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedLocalMatcher(settings.pattern))
+                runner.run_search()
+            else:
+                var runner = ParallelFastaSearchRunner[
+                    StripedLocalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedLocalMatcher(settings.pattern))
+                runner.run_search()
         else:
             raise "Invalid record type: {}".format(settings.record_type)
     elif settings.match_algo == "basic-global":
         if settings.record_type == "line":
-            var runner = LineSearchRunner(
-                settings, BasicGlobalMatcher(settings.pattern)
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = LineSearchRunner(
+                    settings, BasicGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelLineSearchRunner(
+                    settings, BasicGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
         elif settings.record_type == "fasta":
-            var runner = FastaSearchRunner(
-                settings, BasicGlobalMatcher(settings.pattern)
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = FastaSearchRunner(
+                    settings, BasicGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelFastaSearchRunner(
+                    settings, BasicGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
         else:
             raise "Invalid record type: {}".format(settings.record_type)
     elif settings.match_algo == "basic-semi-global":
         if settings.record_type == "line":
-            var runner = LineSearchRunner(
-                settings, BasicSemiGlobalMatcher(settings.pattern)
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = LineSearchRunner(
+                    settings, BasicSemiGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelLineSearchRunner(
+                    settings, BasicSemiGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
         elif settings.record_type == "fasta":
-            var runner = FastaSearchRunner(
-                settings, BasicSemiGlobalMatcher(settings.pattern)
-            )
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = FastaSearchRunner(
+                    settings, BasicSemiGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
+            else:
+                var runner = ParallelFastaSearchRunner(
+                    settings, BasicSemiGlobalMatcher(settings.pattern)
+                )
+                runner.run_search()
         else:
             raise "Invalid record type: {}".format(settings.record_type)
     elif settings.match_algo == "striped-semi-global":
         if settings.record_type == "line":
-            var runner = LineSearchRunner[
-                StripedSemiGlobalMatcher[__origin_of(settings.pattern)]
-            ](settings, StripedSemiGlobalMatcher(settings.pattern))
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = LineSearchRunner[
+                    StripedSemiGlobalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedSemiGlobalMatcher(settings.pattern))
+                runner.run_search()
+            else:
+                var runner = ParallelLineSearchRunner[
+                    StripedSemiGlobalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedSemiGlobalMatcher(settings.pattern))
+                runner.run_search()
         elif settings.record_type == "fasta":
-            var runner = FastaSearchRunner[
-                StripedSemiGlobalMatcher[__origin_of(settings.pattern)]
-            ](settings, StripedSemiGlobalMatcher(settings.pattern))
-            runner.run_search()
+            if settings.threads == 1:
+                var runner = FastaSearchRunner[
+                    StripedSemiGlobalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedSemiGlobalMatcher(settings.pattern))
+                runner.run_search()
+            else:
+                var runner = ParallelFastaSearchRunner[
+                    StripedSemiGlobalMatcher[__origin_of(settings.pattern)]
+                ](settings, StripedSemiGlobalMatcher(settings.pattern))
+                runner.run_search()
         else:
             raise "Invalid record type: {}".format(settings.record_type)
     else:

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -17,7 +17,7 @@ build-bench-128 = "magic run mojo build -D SIMD_MOD=4 --march native  -I ./ishli
 build-bench-256 = "magic run mojo build -D SIMD_MOD=2 --march native  -I ./ishlib -o ish-aligner-256 ./ish_bench_aligner.mojo"
 build-bench-512 = "magic run mojo build -D SIMD_MOD=1 --march native  -I ./ishlib -o ish-aligner-512 ./ish_bench_aligner.mojo"
 build-bench-gpu = "magic run mojo build -D SIMD_MOD=1 --march native  -I ./ishlib -o ish-aligner-gpu ./ish_bench_aligner_gpu.mojo"
-build = "magic run mojo build  -o ish main.mojo"
+build = "magic run mojo build  --march native -o ish main.mojo"
 pkglib = "magic run mojo package ./ishlib"
 testlib = "magic run mojo test -I ishlib -I ../ExtraMojo"
 


### PR DESCRIPTION
Adds a parallel fata and line searcher. In the process this also:
- Removes `mut self` from matcher trait so that they can be used in parallel calls
- Which in turn removes the reused ProfileVectors from the StripedMatcher
- Adds thread and batch size options that will be reusable by gpu parallelization

The plan will be to put the gpu parallel code in the same `parallel` launcher and dispatch there when the gpu(s) are available. 

TODO:
- [ ] Fixup tests to match the new apis
- [ ] Standardize and right-size the SIMD_WIDTH params across all impls